### PR TITLE
DNS-TXT: Use character-string instead of Null terminated C string.

### DIFF
--- a/common/dns.c
+++ b/common/dns.c
@@ -260,7 +260,7 @@ void		dns_simple_decode_strip_dot(char *input, char *output, int max_len)
   
   ptr = input;
   *output = 0;
-  while (*ptr)
+  while (total_len < max_len - 1)
     {
       len = (uint8_t) *ptr;
       /* compression not supported */

--- a/server/rr.c
+++ b/server/rr.c
@@ -140,7 +140,7 @@ void                    *rr_add_reply_encode(t_conf *conf, t_request *req, struc
   rr = rr_add_data(hdr, where, req->reply_functions->reply_type, encoded_data, 0);
   where = JUMP_RR_HDR(rr);
   dns_encode(where);
-  len = strlen(where) + 1; /* len + byte 0 (label data) */
+  len = strlen(where);
   PUT_16(&rr->rdlength,len);
   return (where + len);
 }


### PR DESCRIPTION
When you sniff the DNS TXT records via Wireshark, the responses from the dsn2tcp daemon, you see two so-called `character-string` in each TXT record. The first one has the data. The second one is null bytes long and contains no data. All length bytes/indicators are correct. However, today, I faced a DNS forwarder that does not like null-byte-long character-strings and discards the whole TXT response. Consequently, my dns2tcp client does not get any response either.

The root cause: dns2tcp works with C strings internally. It does null terminate each string in the TXT record. However, in [RFC 1035](https://tools.ietf.org/html/rfc1035#section-3.3.14), `character-string` is defined as a length-value pair rather than string<Null>. I am not sure whether I fixed all places which expect/send a C string via DNS. Tests showed that a patched server still works with unpatched clients. However, unpatched clients send to stderr: `Error while decoding reply max_len was …` Anyway, I do not think this will be included in the upstream project. I am just reporting for those interested, controlling both client/server. And perhaps the maintainer can provide a hint which other places expect/rely on C string.

Anyway, anyway, thanks for `dns2tcp` as it helped me to write an exploit for an Open DNS Resolver. And because of a confirmed DNS Tunneling attack the [CVSS](https://en.wikipedia.org/wiki/Common_Vulnerability_Scoring_System) raised enough, worth reporting it.