### PR TITLE
Satisfy some public resolvers by replying with SERVFAIL to unparsed requests

### DIFF
--- a/client/requests.c
+++ b/client/requests.c
@@ -88,7 +88,7 @@ static int		add_query(struct dns_hdr *hdr, void *where, char *name,
 
 static void	data2qname(t_request *req, void *output)
 {
-  base64_encode((char *)req->req_data, output, req->len);
+  base32_encode((char *)req->req_data, output, req->len);
   strcat(output, ".");
   strcat(output, req->domain);
 #ifndef _WIN32
@@ -133,14 +133,14 @@ static int		create_request(t_conf *conf, void *output, t_request *req)
 
   hdr = (struct dns_hdr *) output; 
   create_req_hdr(conf, hdr);
-  if ((ENCODED_LEN(BASE64_SIZE(req->len)) + strlen(req->domain) + 2 ) > (MAX_HOST_NAME_ENCODED))
+  if ((ENCODED_LEN(BASE32_SIZE(req->len)) + strlen(req->domain) + 2 ) > (MAX_HOST_NAME_ENCODED))
     {
 #ifndef _WIN32
       fprintf(stderr, "send_query : data too long (%d bytes -> %zd bytes)\n", 
 #else
       fprintf(stderr, "send_query : data too long (%d bytes -> %d bytes)\n", 
 #endif
-	      req->len, ENCODED_LEN(BASE64_SIZE(req->len)) + strlen(req->domain) + 2 );
+	      req->len, ENCODED_LEN(BASE32_SIZE(req->len)) + strlen(req->domain) + 2 );
       return (0);
     }
   DPRINTF(3, "Sending dns id = 0x%x\n", ntohs(hdr->id)); 

--- a/common/includes/base64.h
+++ b/common/includes/base64.h
@@ -30,6 +30,9 @@
 #define	BASE64_SIZE(len)		((( (len + 3 - 1 ) / 3 )) * 4)
 #define	DECODED_BASE64_SIZE(len)	((( (len) / 4 ) * 3 ))
 
+#define BASE32_SIZE(len) (((len * 8) + 4) / 5)
+#define DECODED_BASE32_SIZE(len) ((len * 5) / 8)
+
 
 /* 
 took from Apache 1.3.27
@@ -37,6 +40,9 @@ took from Apache 1.3.27
 
 extern int base64_encode(char *string, char *encoded, int len);
 extern int base64_decode(unsigned char *bufplain, const char *bufcoded);
+
+extern int base32_encode(char *string, char *encoded, int len);
+extern int base32_decode(unsigned char *bufplain, const char *bufcoded);
 
 #ifndef HAVE_STRCASESTR
 extern char *strcasestr(const char *, const char *);

--- a/server/requests.c
+++ b/server/requests.c
@@ -165,7 +165,7 @@ int			get_request(t_conf *conf, t_request *req, t_data *output)
       return (-1);
     }
   DPRINTF(3, "Receive query : %s dns_id = 0x%x for domain %s\n", buffer, ntohs(hdr->id), req->domain);
-  return ((output->len = base64_decode((unsigned char *)output->buffer, buffer)));
+  return ((output->len = base32_decode((unsigned char *)output->buffer, buffer)));
 }
 
 /* 


### PR DESCRIPTION
TL;DR—fixes some recursive resolvers not working with dns2tcp.


A couple of popular public resolvers (e.g. Cloudflare `1.1.1.1`, Yandex `77.88.8.8`) don't actually adhere to forwarding client's DNS requests. 

For example, on requesting `TXT AAAAAIoRAA.=auth.your-dns2tcp-domain.com.` they sometimes go and try to resolve `A =auth.your-dns2tcp-domain.com.`
dns2tcpd currently just ignores those requests, which makes the recursive resolver to just timeout and return with SERVFAIL. 

This patch makes dns2tcpd respond with SERVFAIL to unparsed requests. In this case, recursive resolver receives the reply, and re-requests the actual TXT that the client was asking it in the first place.